### PR TITLE
BLAST install fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,6 @@ blast:brew
 	@echo "blastp... installing now..."
 	cd ${DIR}/software && curl -LO ftp://ftp.ncbi.nlm.nih.gov/blast/executables/blast+/LATEST/ncbi-blast-2.7.1+-x64-linux.tar.gz && tar -zxf ncbi-blast-2.7.1+-x64-linux.tar.gz
 	@echo PATH=\$$PATH:${DIR}/software/ncbi-blast-2.7.1+/bin >> pathfile
-endif
 
 spades:brew
 ifdef spades


### PR DESCRIPTION
Removed the orphaned endif from the prior BLAST installation check